### PR TITLE
Allow overriding realtime model selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ client.on('conversation.updated', (event) => {
 });
 
 // Connect to Realtime API
-await client.connect();
+await client.connect({ model: 'gpt-realtime' });
 
 // Send a item and triggers a generation
 client.sendUserMessageContent([{ type: 'input_text', text: `How are you?` }]);

--- a/dist/lib/client.d.ts
+++ b/dist/lib/client.d.ts
@@ -162,9 +162,10 @@ export class RealtimeClient extends RealtimeEventHandler {
      * Create a new RealtimeClient instance
      * @param {{url?: string, apiKey?: string, dangerouslyAllowAPIKeyInBrowser?: boolean, debug?: boolean}} [settings]
      */
-    constructor({ url, apiKey, dangerouslyAllowAPIKeyInBrowser, debug }?: {
+    constructor({ url, apiKey, model, dangerouslyAllowAPIKeyInBrowser, debug }?: {
         url?: string;
         apiKey?: string;
+        model?: string;
         dangerouslyAllowAPIKeyInBrowser?: boolean;
         debug?: boolean;
     });
@@ -191,6 +192,7 @@ export class RealtimeClient extends RealtimeEventHandler {
         prefix_padding_ms: number;
         silence_duration_ms: number;
     };
+    model: string | null;
     realtime: RealtimeAPI;
     conversation: RealtimeConversation;
     /**
@@ -223,7 +225,7 @@ export class RealtimeClient extends RealtimeEventHandler {
      * Updates session config and conversation config
      * @returns {Promise<true>}
      */
-    connect(): Promise<true>;
+    connect({ model }?: { model?: string; }): Promise<true>;
     /**
      * Waits for a session.created event to be executed before proceeding
      * @returns {Promise<true>}

--- a/lib/api.js
+++ b/lib/api.js
@@ -56,7 +56,7 @@ export class RealtimeAPI extends RealtimeEventHandler {
    * @param {{model?: string}} [settings]
    * @returns {Promise<true>}
    */
-  async connect({ model } = { model: 'gpt-4o-realtime-preview-2024-10-01' }) {
+  async connect({ model = 'gpt-4o-realtime-preview-2024-10-01' } = {}) {
     if (!this.apiKey && this.url === this.defaultUrl) {
       console.warn(`No apiKey provided for connection to "${this.url}"`);
     }
@@ -113,7 +113,7 @@ export class RealtimeAPI extends RealtimeEventHandler {
       const wsModule = await import(/* webpackIgnore: true */ moduleName);
       const WebSocket = wsModule.default;
       const ws = new WebSocket(
-        'wss://api.openai.com/v1/realtime?model=gpt-4o-realtime-preview-2024-10-01',
+        `${this.url}${model ? `?model=${model}` : ''}`,
         [],
         {
           finishRequest: (request) => {

--- a/lib/client.js
+++ b/lib/client.js
@@ -189,9 +189,9 @@ import { RealtimeUtils } from './utils.js';
 export class RealtimeClient extends RealtimeEventHandler {
   /**
    * Create a new RealtimeClient instance
-   * @param {{url?: string, apiKey?: string, dangerouslyAllowAPIKeyInBrowser?: boolean, debug?: boolean}} [settings]
+   * @param {{url?: string, apiKey?: string, model?: string, dangerouslyAllowAPIKeyInBrowser?: boolean, debug?: boolean}} [settings]
    */
-  constructor({ url, apiKey, dangerouslyAllowAPIKeyInBrowser, debug } = {}) {
+  constructor({ url, apiKey, model, dangerouslyAllowAPIKeyInBrowser, debug } = {}) {
     super();
     this.defaultSessionConfig = {
       modalities: ['text', 'audio'],
@@ -218,6 +218,7 @@ export class RealtimeClient extends RealtimeEventHandler {
       prefix_padding_ms: 300, // How much audio to include in the audio stream before the speech starts.
       silence_duration_ms: 200, // How long to wait to mark the speech as stopped.
     };
+    this.model = model || null;
     this.realtime = new RealtimeAPI({
       url,
       apiKey,
@@ -389,11 +390,11 @@ export class RealtimeClient extends RealtimeEventHandler {
    * Updates session config and conversation config
    * @returns {Promise<true>}
    */
-  async connect() {
+  async connect({ model } = {}) {
     if (this.isConnected()) {
       throw new Error(`Already connected, use .disconnect() first`);
     }
-    await this.realtime.connect();
+    await this.realtime.connect({ model: model || this.model });
     this.updateSession();
     return true;
   }

--- a/test/tests/api.js
+++ b/test/tests/api.js
@@ -25,6 +25,14 @@ export async function run() {
       expect(event.error.message).to.contain('Incorrect API key provided');
     });
 
+
+      it('Should allow overriding the model when connecting', async () => {
+        realtime.disconnect();
+        await realtime.connect({ model: 'gpt-realtime' });
+        expect(realtime.ws.url).to.contain('model=gpt-realtime');
+        realtime.disconnect();
+      });
+
     it('Should instantiate the RealtimeAPI', () => {
       realtime = new RealtimeAPI({
         apiKey: process.env.OPENAI_API_KEY,


### PR DESCRIPTION
## Summary
- enable `RealtimeAPI.connect` to accept a `model` override in both browser and Node
- support `model` option on `RealtimeClient` and forward to `connect`
- document and test overriding the model

## Testing
- `npm test` *(fails: Timeout of 10000ms exceeded)*

------
https://chatgpt.com/codex/tasks/task_b_68b60b48009083309f37ac3333843b2c